### PR TITLE
WIP: remove Makefile to enable pack install with interactive(false)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,0 @@
-.PHONY: tests
-
-TEST_FILES := $(shell find t -type f -name '*.pl')
-
-tests:
-	@prove -v -e 'swipl -q -t main -s' $(TEST_FILES)  


### PR DESCRIPTION
The presence of the Makefile makes swipl assume that the pack has foreign source requiring compilation via `make all; make check; make install`. As the Makefile doesn't have these goals, `pack_install(julian, [interactive(false)])` results in an error.

Root cause:
- Makefile is classified as a 'foreign file': https://github.com/SWI-Prolog/swipl-devel/blob/master/library/prolog_pack.pl#L1087
- If foreign file exists, run `make all; make check; make install`: https://github.com/SWI-Prolog/swipl-devel/blob/master/library/prolog_pack.pl#L1148

I've marked this WIP until a way is found to either run the tests a different way, or workaround the above problem.

Thanks!